### PR TITLE
swap out split on "=" to use regex. pushed into separate function

### DIFF
--- a/src/python/lv_ui_testing/src/lv_ui_testing/ui_testing.py
+++ b/src/python/lv_ui_testing/src/lv_ui_testing/ui_testing.py
@@ -2,6 +2,7 @@ import zmq
 import logging
 import json
 import xmltodict
+import re
 
 print("start")
 
@@ -134,8 +135,19 @@ def FMV_get_value(control_label, raw = False):
     if raw:
         data = message.decode("utf-8")
     else:
-        data = message.decode("utf-8").split('=')[1]
+        data = extract_value_from_string(message.decode("utf-8"))
 
+    return data
+
+def extract_value_from_string(stringInput):
+    """
+    Given a string input, it will parse and return anything which matches after the last equals sign
+    """
+    match = re.search(r".*=(.*)$", stringInput)
+    if match:
+        data = match.group(1)
+    else:
+        data = ""
     return data
 
 def FMV_get_value_xml(control_label, raw = False):
@@ -202,7 +214,9 @@ def decode_tree(message):
 
     selected_tree_element = []
     for element in data:
-        selected_tree_element.append(element.split("=")[1])
+        match = extract_value_from_string(element)
+        if match:
+            selected_tree_element.append(match)
 
     return selected_tree_element
 
@@ -363,7 +377,7 @@ def SP_get_value(subpanel_label,control_label,raw=False):
     if raw:
         data = message
     else:
-        data = message.decode("utf-8").split('=')[1]
+        data = extract_value_from_string(message.decode("utf-8"))
     return  data
 
 def SP_get_value_TREE(subpanel_label,control_label):
@@ -429,7 +443,7 @@ def SP_SP_get_value(subpanel_label,subsubpanel_label,control_label, raw = False)
     if raw:
         data = message
     else:
-        data = message.decode("utf-8").split('=')[1]
+        data = extract_value_from_string(message.decode("utf-8"))
     return  data
 
 


### PR DESCRIPTION
When testing with LV2023, the string back from LV server ZMQ had multiple "=" characters in response. 
The code currently splits on "=" chars, and grabs the second item in the indexed list. 
Updated to use a regular expression, with a greedy quantifier, to only grab the value after the last = char. 

Pushed out this parsing into a separate function, as I found this in a couple places and thought to consolidate. 

I have only used tests and functionality for functions that call: FMV_get_value method, so other changes may be broken. Further scope to build a test-suite for python library which mocks LV server socket, to test if anything breaks other functionality.

With the original code, the value that got returned by LV ZMQ request was (an example): 
`MGI RWA Section Options=2.0.1 *~\x1b|.\x17*~\x1b|.\x17,*~\x1b|.\x17%#_13gValue=3`

Which broke it. 

The pushed changes fix and get this code working. 